### PR TITLE
Better SB3CombinedLogReward

### DIFF
--- a/rlgym_tools/sb3_utils/sb3_log_reward.py
+++ b/rlgym_tools/sb3_utils/sb3_log_reward.py
@@ -88,7 +88,7 @@ class SB3CombinedLogReward(CombinedReward):
             except PermissionError:
                 pass
             except Exception as e:
-                print(e)
+                print(f'Error obtaining lock in SB3CombinedLogReward.__init__:\n{e}')
 
         # Empty the file
         with open(self.file_location, 'w') as f:
@@ -132,7 +132,7 @@ class SB3CombinedLogReward(CombinedReward):
             except PermissionError:
                 pass
             except Exception as e:
-                print(e)
+                print(f'Error obtaining lock in SB3CombinedLogReward.get_final_reward:\n{e}')
 
         # Write the rewards to file and reset
         with open(self.file_location, 'a') as f:
@@ -180,7 +180,7 @@ class SB3CombinedLogRewardCallback(BaseCallback):
             except PermissionError:
                 pass
             except Exception as e:
-                print(e)
+                print(f'Error obtaining lock in SB3CombinedLogRewardCallback._on_rollout_end:\n{e}')
 
         # Read the file into returns
         with open(self.file_location, 'r') as f:

--- a/rlgym_tools/sb3_utils/sb3_log_reward.py
+++ b/rlgym_tools/sb3_utils/sb3_log_reward.py
@@ -121,8 +121,8 @@ class SB3CombinedLogReward(CombinedReward):
             func.get_final_reward(player, state, previous_action)
             for func in self.reward_functions
         ]
-
-        self.returns += [a * b for a, b in zip(rewards, self.reward_weights)]  # store the rewards
+        # Add the rewards to the cumulative totals with numpy broadcasting
+        self.returns += [a * b for a, b in zip(rewards, self.reward_weights)]
 
         # Obtain the lock
         while True:

--- a/rlgym_tools/sb3_utils/sb3_log_reward.py
+++ b/rlgym_tools/sb3_utils/sb3_log_reward.py
@@ -67,6 +67,8 @@ class SB3CombinedLogReward(CombinedReward):
 
         :param reward_functions: Each individual reward function.
         :param reward_weights: The weights for each reward.
+        :param file_location: The path to the directory that will be used to
+        transfer reward info
         """
         super().__init__(reward_functions, reward_weights)
 
@@ -158,6 +160,8 @@ class SB3CombinedLogRewardCallback(BaseCallback):
 
         :param reward_names: List of names that the logger will use for
         each reward.
+        :param file_location: The path to the directory that will be used to
+        transfer reward info
         """
         super().__init__()
         self.reward_names = reward_names

--- a/rlgym_tools/sb3_utils/sb3_log_reward.py
+++ b/rlgym_tools/sb3_utils/sb3_log_reward.py
@@ -92,9 +92,9 @@ class SB3CombinedLogReward(CombinedReward):
             except Exception as e:
                 print(f'Error obtaining lock in SB3CombinedLogReward.__init__:\n{e}')
 
-        # Empty the file
+        # Empty the file by opening in w mode
         with open(self.file_location, 'w') as f:
-            f.write('')
+            pass
 
         # Release the lock
         try:


### PR DESCRIPTION
I changed it up to use json dumps and loads, and use a single dump file with a lock. I tested that all the exceptions being caught in the obtaining of the lock were the correct ones, and I ran 5 instances of 3v3 with it for 40 minutes without error.

I also made other small changes such as renaming the path to the dump file, and allowing it to be set by the user, and combining the default name allocation of the rewards into the for loop that logs them, using a try: except.

I applied PyCharm's reformat function, and made sure I capitalised the comments, so hopefully the formatting is better this time.