### PR TITLE
fix NameError in KickoffReward

### DIFF
--- a/rlgym_tools/extra_rewards/kickoff_reward.py
+++ b/rlgym_tools/extra_rewards/kickoff_reward.py
@@ -1,6 +1,10 @@
 from rlgym.utils.reward_functions import RewardFunction
 from rlgym.utils.reward_functions.common_rewards.player_ball_rewards import VelocityPlayerToBallReward
 
+from rlgym.utils.gamestates import GameState, PlayerData
+
+from numpy import ndarray
+
 
 class KickoffReward(RewardFunction):
     """
@@ -14,7 +18,7 @@ class KickoffReward(RewardFunction):
         self.vel_dir_reward.reset(initial_state)
 
     def get_reward(
-        self, player: PlayerData, state: GameState, previous_action: np.ndarray
+        self, player: PlayerData, state: GameState, previous_action: ndarray
     ) -> float:
         reward = 0
         if state.ball.position[0] == 0 and state.ball.position[1] == 0:


### PR DESCRIPTION
Prior to this change, importing `KickoffReward` throws a `NameError`
due to type references for GameState, PlayerData, and np.ndarray not
having been imported.