### PR TITLE
fixed minor error in jump_touch_reward.py by importing numpy

### DIFF
--- a/rlgym_tools/extra_rewards/jump_touch_reward.py
+++ b/rlgym_tools/extra_rewards/jump_touch_reward.py
@@ -1,5 +1,6 @@
 from rlgym.utils import RewardFunction
 from rlgym.utils.gamestates import PlayerData, GameState
+import numpy as np
 
 class JumpTouchReward(RewardFunction):
     """


### PR DESCRIPTION
fixed small issue in jump_touch_reward where numpy was not imported.

`rlgym_tools\extra_rewards\jump_touch_reward.py", line 18, in JumpTouchReward
    self, player: PlayerData, state: GameState, previous_action: np.ndarray
NameError: name 'np' is not defined`

is caused by type restriction in the definition of get_reward
`    def get_reward(
            self, player: PlayerData, state: GameState, previous_action: np.ndarray
            ) -> float:`
            
this is solved by adding the following to the top of the file:

`import numpy as np`