### PR TITLE
Update parse_actions in lookup_act.py

### DIFF
--- a/rlgym_tools/extra_action_parsers/lookup_act.py
+++ b/rlgym_tools/extra_action_parsers/lookup_act.py
@@ -50,4 +50,5 @@ class LookupAction(ActionParser):
         return Discrete(len(self._lookup_table))
 
     def parse_actions(self, actions: Any, state: GameState) -> np.ndarray:
-        return self._lookup_table[actions]
+        indexes = np.array(actions, dtype=np.int32)
+        return self._lookup_table[indexes]

--- a/rlgym_tools/extra_action_parsers/lookup_act.py
+++ b/rlgym_tools/extra_action_parsers/lookup_act.py
@@ -51,4 +51,5 @@ class LookupAction(ActionParser):
 
     def parse_actions(self, actions: Any, state: GameState) -> np.ndarray:
         indexes = np.array(actions, dtype=np.int32)
+        indexes = np.squeeze(indexes)
         return self._lookup_table[indexes]


### PR DESCRIPTION
The argument "actions" for the function "parse_actions" may not be an array of integers by default, likely more often being floats, so trying to convert the array first is safer. This way also makes sure that actions is an ndarray for the sake of converting the type.